### PR TITLE
Refactor: use testing library on unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'react-native',
+  setupFilesAfterEnv: ['./jest.setup.js'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   modulePathIgnorePatterns: ['<rootDir>/lib/'],
   testMatch: ['**/?(*.)+(test).js'],

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,3 @@
+import { toHaveStyle } from '@testing-library/jest-native';
+
+expect.extend({ toHaveStyle });

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@react-native-community/eslint-plugin": "^1.1.0",
     "@release-it/conventional-changelog": "^1.1.4",
     "@testing-library/jest-native": "^3.1.0",
+    "@testing-library/react-native": "^7.2.0",
     "@types/highlight-words-core": "^1.2.0",
     "@types/jest": "^25.2.3",
     "@types/react-native": "^0.62.12",

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -1,15 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<HighlightText /> should render properly 1`] = `
+exports[`<HighlightText /> should detect all ocurrencies of searched words in textToHighlight prop 1`] = `
 <Text>
-  In this text we can do a 
+  I'm 
   <Text>
-    hello
+    Slim
   </Text>
-   to the entire 
+   
   <Text>
-    world
+    Shady
   </Text>
+  , yes, I'm the real 
+  <Text>
+    Shady
+  </Text>
+  . All you other 
+  <Text>
+    Slim
+  </Text>
+   
+  <Text>
+    Shady
+  </Text>
+  s, are just imitating. So won't the real 
+  <Text>
+    Slim
+  </Text>
+   
+  <Text>
+    Shady
+  </Text>
+  , please stand up?
 </Text>
 `;
 
@@ -70,6 +91,19 @@ exports[`<HighlightText /> should render properly with custom styles 1`] = `
       }
     }
   >
+    world
+  </Text>
+</Text>
+`;
+
+exports[`<HighlightText /> should wrap each matched search word with an isolated element 1`] = `
+<Text>
+  In this text we can do a 
+  <Text>
+    hello
+  </Text>
+   to the entire 
+  <Text>
     world
   </Text>
 </Text>

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,30 +1,56 @@
 import React from 'react';
 import { Text } from 'react-native';
-import { create } from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
 
 import HighlightText from '../';
 
 describe('<HighlightText />', () => {
-  it('should render properly', () => {
-    const wrapper = create(
-      <HighlightText
-        searchWords={['hello', 'world']}
-        textToHighlight={'In this text we can do a hello to the entire world'}
-      />
-    );
-    expect(wrapper.toJSON()).toMatchSnapshot();
+  it('should wrap each matched search word with an isolated element', () => {
+    const props = {
+      searchWords: ['hello', 'world'],
+      textToHighlight: 'In this text we can do a hello to the entire world',
+    };
+    const { queryByText, toJSON } = render(<HighlightText {...props} />);
+
+    for (const word of props.searchWords) {
+      expect(queryByText(word)).toBeTruthy();
+    }
+
+    expect(toJSON()).toMatchSnapshot();
+  });
+
+  it('should detect all ocurrencies of searched words in textToHighlight prop', () => {
+    const props = {
+      searchWords: ['Slim', 'Shady'],
+      textToHighlight:
+        "I'm Slim Shady, yes, I'm the real Shady. All you other Slim Shadys, are just imitating. So won't the real Slim Shady, please stand up?",
+    };
+    const { queryAllByText, toJSON } = render(<HighlightText {...props} />);
+
+    const allSlims = queryAllByText('Slim');
+    const allShadys = queryAllByText('Shady');
+
+    expect(allSlims).toHaveLength(3);
+    expect(allShadys).toHaveLength(4);
+
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('should render properly with custom styles', () => {
-    const wrapper = create(
-      <HighlightText
-        searchWords={['hello', 'world']}
-        textToHighlight={'In this text we can do a hello to the entire world'}
-        style={{ color: 'darkgray' }}
-        highlightStyle={{ color: 'blue' }}
-      />
-    );
-    expect(wrapper.toJSON()).toMatchSnapshot();
+    const props = {
+      searchWords: ['hello', 'world'],
+      textToHighlight: 'In this text we can do a hello to the entire world',
+      style: { color: 'darkgray' },
+      highlightStyle: { color: 'blue' },
+    };
+
+    const { queryByText, toJSON } = render(<HighlightText {...props} />);
+
+    for (const word of props.searchWords) {
+      expect(queryByText(word)).toHaveStyle(props.highlightStyle);
+    }
+
+    expect(toJSON()).toMatchSnapshot();
   });
 
   it('should render properly with custom components', () => {
@@ -34,7 +60,7 @@ describe('<HighlightText />', () => {
     const CustomHighlight = (props) => (
       <Text style={{ fontWeight: 'bold' }}>{props.children}</Text>
     );
-    const wrapper = create(
+    const { toJSON } = render(
       <HighlightText
         searchWords={['hello', 'world']}
         textToHighlight={'In this text we can do a hello to the entire world'}
@@ -42,6 +68,6 @@ describe('<HighlightText />', () => {
         highlightComponent={CustomHighlight}
       />
     );
-    expect(wrapper).toMatchSnapshot();
+    expect(toJSON()).toMatchSnapshot();
   });
 });

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -27,11 +27,8 @@ describe('<HighlightText />', () => {
     };
     const { queryAllByText, toJSON } = render(<HighlightText {...props} />);
 
-    const allSlims = queryAllByText('Slim');
-    const allShadys = queryAllByText('Shady');
-
-    expect(allSlims).toHaveLength(3);
-    expect(allShadys).toHaveLength(4);
+    expect(getAllByText('Slim')).toHaveLength(3);
+    expect(getAllByText('Shady')).toHaveLength(4);
 
     expect(toJSON()).toMatchSnapshot();
   });

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -25,7 +25,7 @@ describe('<HighlightText />', () => {
       textToHighlight:
         "I'm Slim Shady, yes, I'm the real Shady. All you other Slim Shadys, are just imitating. So won't the real Slim Shady, please stand up?",
     };
-    const { queryAllByText, toJSON } = render(<HighlightText {...props} />);
+    const { getAllByText, toJSON } = render(<HighlightText {...props} />);
 
     expect(getAllByText('Slim')).toHaveLength(3);
     expect(getAllByText('Shady')).toHaveLength(4);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2004,6 +2004,13 @@
     ramda "^0.26.1"
     redent "^2.0.0"
 
+"@testing-library/react-native@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-7.2.0.tgz#e5ec5b0974e4e5f525f8057563417d1e9f820d96"
+  integrity sha512-rDKzJjAAeGgyoJT0gFQiMsIL09chdWcwZyYx6WZHMgm2c5NDqY52hUuyTkzhqddMYWmSRklFphSg7B2HX+246Q==
+  dependencies:
+    pretty-format "^26.0.1"
+
 "@types/babel__core@^7.1.7":
   version "7.1.8"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.8.tgz#057f725aca3641f49fc11c7a87a9de5ec588a5d7"


### PR DESCRIPTION
This PR adds the usage of react native's testing-library module, as well as new test suites for cases of multiple occurrences of search words on `textToHighlight` property. 
