### PR TITLE
installing in a TypeScript shows errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "url": "git+https://github.com/sanar/react-native-highlight-text.git"
   },
   "dependencies": {
-    "highlight-words-core": "^1.2.0",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
@@ -86,7 +85,8 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "highlight-words-core": "^1.2.0"
   },
   "husky": {
     "hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5262,11 +5262,6 @@ hermes-engine@^0.2.1:
   resolved "https://registry.yarnpkg.com/hermes-engine/-/hermes-engine-0.2.1.tgz#25c0f1ff852512a92cb5c5cc47cf967e1e722ea2"
   integrity sha512-eNHUQHuadDMJARpaqvlCZoK/Nitpj6oywq3vQ3wCwEsww5morX34mW5PmKWQTO7aU0ck0hgulxR+EVDlXygGxQ==
 
-highlight-words-core@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/highlight-words-core/-/highlight-words-core-1.2.2.tgz#1eff6d7d9f0a22f155042a00791237791b1eeaaa"
-  integrity sha512-BXUKIkUuh6cmmxzi5OIbUJxrG8OAk2MqoL1DtO3Wo9D2faJg2ph5ntyuQeLqaHJmzER6H5tllCDA9ZnNe9BVGg==
-
 hosted-git-info@^2.1.4:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"


### PR DESCRIPTION
Changed highlight-words-core to be peer dependency instead of dependency. due to an issue with TypeScript 
`interface HighlightTextProps extends FindAllArgs` was not really working, and typing errors are shown for props when using the component in a typescript project.

